### PR TITLE
Zn past orders

### DIFF
--- a/bangazonapp/views/order.py
+++ b/bangazonapp/views/order.py
@@ -82,6 +82,7 @@ class Orders(ViewSet):
         else:
             customer = getUser(request)
             orders = orders.filter(customer__id=customer.id)
+            orders = orders.filter(payment_type__isnull=False)
 
         serializer = OrderSerializer(
             orders, many=True, context={'request': request})

--- a/bangazonapp/views/order.py
+++ b/bangazonapp/views/order.py
@@ -73,13 +73,13 @@ class Orders(ViewSet):
 
     def list(self, request):
         orders = Order.objects.all()  # This is my query to the database
-
+        closed = self.request.query_params.get('closed', None)
         paymenttype = self.request.query_params.get('paymenttype', None)
         if paymenttype is not None:
             customer = getUser(request)
             orders = orders.filter(customer__id=customer.id)
             orders = orders.filter(payment_type=None)
-        else:
+        elif closed is not None:
             customer = getUser(request)
             orders = orders.filter(customer__id=customer.id)
             orders = orders.filter(payment_type__isnull=False)

--- a/bangazonapp/views/order.py
+++ b/bangazonapp/views/order.py
@@ -79,6 +79,9 @@ class Orders(ViewSet):
             customer = getUser(request)
             orders = orders.filter(customer__id=customer.id)
             orders = orders.filter(payment_type=None)
+        else:
+            customer = getUser(request)
+            orders = orders.filter(customer__id=customer.id)
 
         serializer = OrderSerializer(
             orders, many=True, context={'request': request})


### PR DESCRIPTION
Can now view list of completed orders (orders with payment_type added) on Account view. List is hyperlinked order numbers (order ids in the database). Clicking on a link takes you to an order details view that shows all products in order and order total + two btns to go home or back to account.

Made changes to orderproducts view and orders list view. Orders list view now accepts "closed" parameter if you only want closed orders back for current customer. 